### PR TITLE
feat: release-tag 자동화 설정

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,7 +3,7 @@ name: git push into another repo to deploy to vercel
 on:
   push:
     branches:
-      - release-1.0
+      - develop
       - main
 
 jobs:

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -1,0 +1,20 @@
+name: Release Tag
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 버전 정보 추출
+        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        id: extract_version_name
+      - name: Release 생성
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.extract_version_name.outputs.version }}
+          release_name: ${{ steps.extract_version_name.outputs.version }}


### PR DESCRIPTION
# 구현 내용/방법

> 간단하게 구현한 내용과 방법에 대한 설명
> 
- release-tag 자동화 설정했습니다.


## 앞으로의 진행방식

이번에 release v1.0.0 노트를 작성했습니다. (임의로 진행해서 수정하고 싶으시면 직접하셔도 됩니다!)
release-1.0 브랜치는 현 시점부터 사용하지 않습니다.

배포 브랜치: main
개발 브랜치: develop
이슈 생성 후 브랜치 생성: develop -> fix/#291 ~~~  (develop 브랜치에서 작업할 브랜치를 생성합니다.)
작업 완료: develop <- fix/#291 ~~~ (develop 브랜치로 병합합니다.)
develop 브랜치에서 release-1.0.1 (예시) 브랜치로 checkout 한 후 push 합니다.
main <- release-1.0.1 를 머지해서 배포합니다.

궁금하신 점이나 의견이 있으시면 남겨주세요!


close #278 

